### PR TITLE
OXT-1067: Unfork: Switch to upstream Xen version of OCaml libs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18,7 +18,7 @@
 
 include common.make
 
-PACKAGES = str,uuid,stdext,log,bigarray,camomile,json,jsonrpc,http,dbus,tscommon,mmap,xb,xs
+PACKAGES = str,uuid,stdext,log,bigarray,camomile,json,jsonrpc,http,dbus,tscommon,xenmmap,xenbus,xenstore
 OCAMLC   = ocamlfind ocamlc -linkpkg -package $(PACKAGES)
 OCAMLOPT = ocamlfind ocamlopt -linkpkg -package $(PACKAGES)
 

--- a/httpserver.ml
+++ b/httpserver.ml
@@ -366,15 +366,15 @@ let set_server el h fd =
 			    }
 
 let with_xs f =
-	let xs = Xs.daemon_open () in
-	let v = try f xs with e -> (Xs.close xs; raise e) in
-	Xs.close xs;
+	let xs = Xenstore.Xs.daemon_open () in
+	let v = try f xs with e -> (Xenstore.Xs.close xs; raise e) in
+	Xenstore.Xs.close xs;
 	v
 
 let uuid_of_domid domid =
 	with_xs (fun xs ->
-			 let path = xs.Xs.read ("/local/domain/" ^ string_of_int domid ^ "/vm") in
-			 xs.Xs.read (path ^ "/uuid"))
+			 let path = xs.Xenstore.Xs.read ("/local/domain/" ^ string_of_int domid ^ "/vm") in
+			 xs.Xenstore.Xs.read (path ^ "/uuid"))
 let domid_of_ipstring str =
 	let h = List.hd (List.rev (String.split '.' str)) in
 	int_of_string h


### PR DESCRIPTION
The OCaml library names changed in 2011.
( xen.git 7ceaa0c7449e841d7ca7db889c3041dc3fedbb3b )

Makefile updated and references to Xs changed to Xenstore.Xs

Signed-off-by: Christopher Clark <christopher.clark6@baesystems.com>