### PR TITLE
OXT-1787: ocamlfind: use across the board for libraries

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -19,10 +19,8 @@
 include common.make
 
 PACKAGES = str,uuid,stdext,log,bigarray,camomile,json,jsonrpc,http,dbus,tscommon,xenmmap,xenbus,xenstore
-OCAMLC   = ocamlfind ocamlc -linkpkg -package $(PACKAGES)
-OCAMLOPT = ocamlfind ocamlopt -linkpkg -package $(PACKAGES)
-
-OCAMLOPTFLAGS += -thread
+OCAMLCFLAGS += -linkpkg -package $(PACKAGES)
+OCAMLOPTFLAGS += -linkpkg -package $(PACKAGES) -thread
 
 INTF = dbus_signals.cmi httpserver.cmi
 uid_OBJS = utils ui_config dBus_conv dbus_signals httpserver server dbus_interface file_handler dBus_handler main

--- a/Makefile.rules
+++ b/Makefile.rules
@@ -17,13 +17,13 @@ endif
 ALL_OCAML_OBJS ?= $(OBJS)
 
 %.cmo: %.ml
-	$(call quiet-command, $(OCAMLC) $(OCAMLCFLAGS) -c -o $@ $<,MLC,$@)
+	$(call quiet-command, ocamlfind $(OCAMLC) $(OCAMLCFLAGS) -c -o $@ $<,MLC,$@)
 
 %.cmi: %.mli
-	$(call quiet-command, $(OCAMLC) $(OCAMLCFLAGS) -c -o $@ $<,MLI,$@)
+	$(call quiet-command, ocamlfind $(OCAMLC) $(OCAMLCFLAGS) -c -o $@ $<,MLI,$@)
 
 %.cmx: %.ml
-	$(call quiet-command, $(OCAMLOPT) $(OCAMLOPTFLAGS) -c -o $@ $<,MLOPT,$@)
+	$(call quiet-command, ocamlfind $(OCAMLOPT) $(OCAMLOPTFLAGS) -c -o $@ $<,MLOPT,$@)
 
 %.ml: %.mll
 	$(call quiet-command, $(OCAMLLEX) -q -o $@ $<,MLLEX,$@)
@@ -47,8 +47,8 @@ clean: $(CLEAN_HOOKS)
 
 quiet-command = $(if $(V),$1,@printf " %-8s %s\n" "$2" "$3" && $1)
 
-mk-caml-lib-native = $(call quiet-command, $(OCAMLOPT) $(OCAMLOPTFLAGS) -a -o $1 $2 $3,MLA,$1)
-mk-caml-lib-bytecode = $(call quiet-command, $(OCAMLC) $(OCAMLCFLAGS) -a -o $1 $2 $3,MLA,$1)
+mk-caml-lib-native = $(call quiet-command, ocamlfind $(OCAMLOPT) $(OCAMLOPTFLAGS) -a -o $1 $2 $3,MLA,$1)
+mk-caml-lib-bytecode = $(call quiet-command, ocamlfind $(OCAMLC) $(OCAMLCFLAGS) -a -o $1 $2 $3,MLA,$1)
 
 mk-caml-stubs = $(call quiet-command, $(OCAMLMKLIB) -o `basename $1 .a` $2,MKLIB,$1)
 mk-caml-lib-stubs = \
@@ -75,9 +75,9 @@ endef
 
 define OCAML_PROGRAM_template
  $(1): $(foreach obj,$($(1)_OBJS),$(obj).cmx) $($(1)_EXTRA_DEPS)
-	$(call quiet-command, $(OCAMLOPT) $(OCAMLOPTFLAGS) -o $$@ $($(1)_LIBS) $$+,MLBIN,$$@)
+	$(call quiet-command, ocamlfind $(OCAMLOPT) $(OCAMLOPTFLAGS) -o $$@ $($(1)_LIBS) $$+,MLBIN,$$@)
  $(1).byte: $(foreach obj,$($(1)_OBJS),$(obj).cmo)
-	$(call quiet-command, $(OCAMLC) $(OCAMLCFLAGS) -o $$@ $($(1)_BYTE_LIBS) $$+,MLBIN,$$@)
+	$(call quiet-command, ocamlfind $(OCAMLC) $(OCAMLCFLAGS) -o $$@ $($(1)_BYTE_LIBS) $$+,MLBIN,$$@)
 endef
 
 define C_PROGRAM_template


### PR DESCRIPTION
ocamlfind is a frontend with the package manager.
uid uses it to find the necessary options to pass to ocamlc/ocamlopt in order
to use the packages managed by findlib (ocamlfind <ocamlc|ocamlopt> -package).
This is done by overriding the OCAMLC/OCAMLOPT variables that are already used
by ocaml.bbclass to pass the cross environment options.

In order to avoid re-writing more build-system bits, use ocamlfind for every library
to invoke the byte-code and native compiler and pass additional package
(-linkpkg/-package) options through OCAMLCOPT and OCAMLOPTOPT. This way OCAMLC
and OCAMLOPT can define the specific cross environment and ocamlfind can
provide its services to include packages through findlib.